### PR TITLE
Fixes GroupLogFile example early-shutdown

### DIFF
--- a/src/main/scala/sample/stream/GroupLogFile.scala
+++ b/src/main/scala/sample/stream/GroupLogFile.scala
@@ -1,10 +1,9 @@
 package sample.stream
 
 import akka.actor.ActorSystem
+import akka.stream.scaladsl.{ Sink, Source }
+import akka.stream.{ FlowMaterializer, OverflowStrategy }
 import java.io.{ FileOutputStream, PrintWriter }
-import akka.stream.FlowMaterializer
-import akka.stream.scaladsl.Source
-
 import scala.util.Try
 
 object GroupLogFile {
@@ -18,6 +17,7 @@ object GroupLogFile {
     implicit val materializer = FlowMaterializer()
 
     val LoglevelPattern = """.*\[(DEBUG|INFO|WARN|ERROR)\].*""".r
+    val maximumLogLevelCount = 5
 
     // read lines from a log file
     val logFile = io.Source.fromFile("src/main/resources/logfile.txt", "utf-8")
@@ -29,16 +29,20 @@ object GroupLogFile {
         case other                  => "OTHER"
       }.
       // write lines of each group to a separate file
-      foreach {
+      map {
         case (level, groupFlow) =>
           val output = new PrintWriter(new FileOutputStream(s"target/log-$level.txt"), true)
           // close resource when the group stream is completed
           // foreach returns a future that we can key the close() off of
-          groupFlow.foreach(line => output.println(line)).onComplete(_ => Try(output.close()))
+          groupFlow.
+            foreach(line => output.println(line)).
+            andThen { case t => output.close(); t.get }
       }.
-      onComplete { _ =>
+      buffer(maximumLogLevelCount, OverflowStrategy.error).
+      mapAsync(identity).
+      runWith(Sink.onComplete { _ =>
         Try(logFile.close())
         system.shutdown()
-      }
+      })
   }
 }


### PR DESCRIPTION
This is my best attempt at writing idiomatic akka-stream code.

Although I agree that it's optimal, the `buffer`, `mapAsyncUnordered`, and `foreach` feels like a lot of steps to do something as simple as "wait for all of these promises to end and then give me a future". Maybe a new method, `foreachAsync`, could help? (although, then do you implement `foreachAsyncUnordered`, also? Don't want to encourage API Cartesian explosion).

Another idea might be to add a `onComplete` method to `Source`, that yields a Try[Unit] when the stream is completed?

I was tempted to have each mapped group yield a `Future[PrintWriter]`, but yielding stateful objects through a stream felt wrong. It seemed better to have the stream close declaration close to the stream open, also, even though it ended up being more verbose.

