### PR TITLE
Upgrade to 2.0.1.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ version := "1.1"
 scalaVersion := "2.11.7"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-stream-experimental" % "2.0-M1"
+  "com.typesafe.akka" %% "akka-stream-experimental" % "2.0.1"
 )
 
 scalariformSettings

--- a/src/main/scala/sample/stream/BasicTransformation.scala
+++ b/src/main/scala/sample/stream/BasicTransformation.scala
@@ -18,7 +18,7 @@ object BasicTransformation {
          |when an unknown printer took a galley of type and scrambled it to make a type
          |specimen book.""".stripMargin
 
-    Source(() => text.split("\\s").iterator).
+    Source.fromIterator(() => text.split("\\s").iterator).
       map(_.toUpperCase).
       runForeach(println).
       onComplete(_ => system.shutdown())

--- a/src/main/scala/sample/stream/GroupLogFile.scala
+++ b/src/main/scala/sample/stream/GroupLogFile.scala
@@ -25,21 +25,25 @@ object GroupLogFile {
     // read lines from a log file
     val logFile = new File("src/main/resources/logfile.txt")
 
-    import akka.stream.io.Implicits._ // add file sources to Source object or use explicitly: SynchronousFileSource(f)
-    Source.synchronousFile(logFile).
+    FileIO.fromFile(logFile).
       // parse chunks of bytes into lines
       via(Framing.delimiter(ByteString(System.lineSeparator), maximumFrameLength = 512, allowTruncation = true)).
       map(_.utf8String).
+      map {
+        case line@LoglevelPattern(level) => (level, line)
+        case line@other => ("OTHER", line)
+      }.
       // group them by log level
-      groupBy {
-        case LoglevelPattern(level) => level
-        case other                  => "OTHER"
+      groupBy(5, _._1).
+      fold(("", List.empty[String])) {
+        case ((_, list), (level, line)) => (level, line :: list)
       }.
       // write lines of each group to a separate file
       mapAsync(parallelism = 5) {
-        case (level, groupFlow) =>
-          groupFlow.map(line => ByteString(line + "\n")).runWith(Sink.synchronousFile(new File(s"target/log-$level.txt")))
+        case (level, groupList) =>
+          Source(groupList.reverse).map(line => ByteString(line + "\n")).runWith(FileIO.toFile(new File(s"target/log-$level.txt")))
       }.
+      mergeSubstreams.
       runWith(Sink.onComplete { _ =>
         system.shutdown()
       })

--- a/tutorial/index.html
+++ b/tutorial/index.html
@@ -156,7 +156,7 @@ filter(line => line.length > 3).
 
 <p>
 All stream manipulation operations can be found in the
-<a href="http://doc.akka.io/api/akka-stream-and-http-experimental/2.0-M1/#akka.stream.scaladsl.package" target="_blank">API documentation</a>.
+<a href="http://doc.akka.io/api/akka-stream-and-http-experimental/2.0.1/#akka.stream.scaladsl.package" target="_blank">API documentation</a>.
 </p>
 
 </div>
@@ -351,7 +351,7 @@ Type a few characters in the telnet session and press enter to see them echoed b
 <h2>Links</h2>
 
 <ul>
-<li><a href="http://doc.akka.io/api/akka-stream-and-http-experimental/2.0-M1/#akka.stream.scaladsl.package" target="_blank">Akka Streams 2.0-M1 API documentation</a></li>
+<li><a href="http://doc.akka.io/api/akka-stream-and-http-experimental/2.0.1/#akka.stream.scaladsl.package" target="_blank">Akka Streams 2.0.1 API documentation</a></li>
 <li><a href="http://www.reactive-streams.org/" target="_blank">Reactive Streams</a></li>
 </ul>
 


### PR DESCRIPTION
Updated BasicTransformation and WritePrimes to use `Source.fromIterator`.
Updated GroupLogFile and WritePrimes to use `FileIO`.
Updated WritePrimes to use `GraphDSL`.
Updated GroupLogFile to use `fold` because `groupBy` return SubFlow.

I updated based on this. [Migration Guide 1.0 to 2.x](http://doc.akka.io/docs/akka-stream-and-http-experimental/2.0.1/scala/migration-guide-1.0-2.x-scala.html)